### PR TITLE
Allow multiple spl-token versions

### DIFF
--- a/.github/actions/build-program/action.yml
+++ b/.github/actions/build-program/action.yml
@@ -11,6 +11,6 @@ runs:
     - name: build-program
       working-directory: ./program
       run: |
-        cargo +${{ env.RUST_STABLE }} build-bpf --version
-        cargo +${{ env.RUST_STABLE }} build-bpf --bpf-out-dir target/deploy/
+        cargo +${{ env.RUST_TOOLCHAIN }} build-bpf --version
+        cargo +${{ env.RUST_TOOLCHAIN }} build-bpf --bpf-out-dir target/deploy/
       shell: bash

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -187,6 +187,7 @@ pub fn withdraw(
     metadata: Pubkey,
     edition: Pubkey,
     rule_set: Pubkey,
+    spl_token_program: Pubkey,
     args: WithdrawArgs,
 ) -> Instruction {
     let (owner_token_record, _) = find_token_record_account(&mint, &token);
@@ -208,7 +209,7 @@ pub fn withdraw(
             AccountMeta::new_readonly(mpl_token_metadata::ID, false),
             AccountMeta::new_readonly(solana_program::system_program::id(), false),
             AccountMeta::new_readonly(solana_program::sysvar::instructions::id(), false),
-            AccountMeta::new_readonly(SPL_TOKEN_PROGRAM_ID, false),
+            AccountMeta::new_readonly(spl_token_program, false),
             AccountMeta::new_readonly(SPL_ATA_TOKEN_PROGRAM_ID, false),
             AccountMeta::new_readonly(MPL_TOKEN_AUTH_RULES_PROGRAM_ID, false),
             AccountMeta::new_readonly(rule_set, false),
@@ -226,6 +227,7 @@ pub fn delegate(
     metadata: Pubkey,
     edition: Pubkey,
     authorization_rules: Option<Pubkey>,
+    spl_token_program: Pubkey,
     args: DelegateArgs,
 ) -> Instruction {
     let (token_record, _bump) = find_token_record_account(&mint, &token);
@@ -243,7 +245,7 @@ pub fn delegate(
             AccountMeta::new_readonly(mpl_token_metadata::ID, false),
             AccountMeta::new_readonly(solana_program::system_program::id(), false),
             AccountMeta::new_readonly(solana_program::sysvar::instructions::id(), false),
-            AccountMeta::new_readonly(SPL_TOKEN_PROGRAM_ID, false),
+            AccountMeta::new_readonly(spl_token_program, false),
             AccountMeta::new_readonly(MPL_TOKEN_AUTH_RULES_PROGRAM_ID, false),
             AccountMeta::new_readonly(
                 authorization_rules.ok_or(mpl_token_metadata::ID).unwrap(),
@@ -262,6 +264,7 @@ pub fn lock(
     mint: Pubkey,
     metadata: Pubkey,
     edition: Pubkey,
+    spl_token_program: Pubkey,
     args: LockArgs,
 ) -> Instruction {
     Instruction {
@@ -276,7 +279,7 @@ pub fn lock(
             AccountMeta::new_readonly(mpl_token_metadata::ID, false),
             AccountMeta::new_readonly(solana_program::system_program::id(), false),
             AccountMeta::new_readonly(solana_program::sysvar::instructions::id(), false),
-            AccountMeta::new_readonly(SPL_TOKEN_PROGRAM_ID, false),
+            AccountMeta::new_readonly(spl_token_program, false),
             AccountMeta::new_readonly(MPL_TOKEN_AUTH_RULES_PROGRAM_ID, false),
             AccountMeta::new_readonly(mpl_token_metadata::ID, false),
         ],
@@ -292,6 +295,7 @@ pub fn unlock(
     mint: Pubkey,
     metadata: Pubkey,
     edition: Pubkey,
+    spl_token_program: Pubkey,
     args: UnlockArgs,
 ) -> Instruction {
     Instruction {
@@ -306,7 +310,7 @@ pub fn unlock(
             AccountMeta::new_readonly(mpl_token_metadata::ID, false),
             AccountMeta::new_readonly(solana_program::system_program::id(), false),
             AccountMeta::new_readonly(solana_program::sysvar::instructions::id(), false),
-            AccountMeta::new_readonly(SPL_TOKEN_PROGRAM_ID, false),
+            AccountMeta::new_readonly(spl_token_program, false),
             AccountMeta::new_readonly(MPL_TOKEN_AUTH_RULES_PROGRAM_ID, false),
             AccountMeta::new_readonly(mpl_token_metadata::ID, false),
         ],
@@ -323,6 +327,7 @@ pub fn programmable_lock(
     metadata: Pubkey,
     edition: Pubkey,
     authorization_rules: Option<Pubkey>,
+    spl_token_program: Pubkey,
     args: LockArgs,
 ) -> Instruction {
     let (token_record, _) = find_token_record_account(&mint, &token);
@@ -340,7 +345,7 @@ pub fn programmable_lock(
             AccountMeta::new_readonly(mpl_token_metadata::ID, false),
             AccountMeta::new_readonly(solana_program::system_program::id(), false),
             AccountMeta::new_readonly(solana_program::sysvar::instructions::id(), false),
-            AccountMeta::new_readonly(SPL_TOKEN_PROGRAM_ID, false),
+            AccountMeta::new_readonly(spl_token_program, false),
             AccountMeta::new_readonly(MPL_TOKEN_AUTH_RULES_PROGRAM_ID, false),
             AccountMeta::new_readonly(
                 authorization_rules.ok_or(mpl_token_metadata::ID).unwrap(),
@@ -360,6 +365,7 @@ pub fn programmable_unlock(
     metadata: Pubkey,
     edition: Pubkey,
     authorization_rules: Option<Pubkey>,
+    spl_token_program: Pubkey,
     args: UnlockArgs,
 ) -> Instruction {
     let (token_record, _) = find_token_record_account(&mint, &token);
@@ -377,7 +383,7 @@ pub fn programmable_unlock(
             AccountMeta::new_readonly(mpl_token_metadata::ID, false),
             AccountMeta::new_readonly(solana_program::system_program::id(), false),
             AccountMeta::new_readonly(solana_program::sysvar::instructions::id(), false),
-            AccountMeta::new_readonly(SPL_TOKEN_PROGRAM_ID, false),
+            AccountMeta::new_readonly(spl_token_program, false),
             AccountMeta::new_readonly(MPL_TOKEN_AUTH_RULES_PROGRAM_ID, false),
             AccountMeta::new_readonly(
                 authorization_rules.ok_or(mpl_token_metadata::ID).unwrap(),
@@ -400,6 +406,7 @@ pub fn delegate_transfer(
     destination_token: Pubkey,
     mint: Pubkey,
     rule_set: Pubkey,
+    spl_token_program: Pubkey,
     args: DelegateTransferArgs,
 ) -> Instruction {
     let (metadata, _) = find_metadata_account(&mint);
@@ -424,7 +431,7 @@ pub fn delegate_transfer(
             AccountMeta::new_readonly(mpl_token_metadata::ID, false),
             AccountMeta::new_readonly(solana_program::system_program::id(), false),
             AccountMeta::new_readonly(solana_program::sysvar::instructions::id(), false),
-            AccountMeta::new_readonly(SPL_TOKEN_PROGRAM_ID, false),
+            AccountMeta::new_readonly(spl_token_program, false),
             AccountMeta::new_readonly(SPL_ATA_TOKEN_PROGRAM_ID, false),
             AccountMeta::new_readonly(MPL_TOKEN_AUTH_RULES_PROGRAM_ID, false),
             AccountMeta::new_readonly(rule_set, false),

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -26,7 +26,6 @@ pub use mpl_token_metadata::{processor::AuthorizationData, state::TokenDelegateR
 
 solana_program::declare_id!("Roostrnex2Z9Y2XZC49sFAdZARP8E4iFpEnZC5QJWdz");
 
-pub const SPL_TOKEN_PROGRAM_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 pub const SPL_ATA_TOKEN_PROGRAM_ID: Pubkey =
     pubkey!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
 pub const MPL_TOKEN_AUTH_RULES_PROGRAM_ID: Pubkey =

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -119,6 +119,7 @@ pub fn withdraw(
         .destination_token_record(*destination_token_record_info.key)
         .authorization_rules(*rule_set_info.key)
         .authorization_rules_program(*mpl_token_auth_rules_program_info.key)
+        .spl_token_program(*spl_token_program_info.key)
         .payer(*authority_info.key);
 
     msg!("building transfer instruction");
@@ -272,6 +273,7 @@ pub fn lock(_program_id: &Pubkey, accounts: &[AccountInfo], args: LockArgs) -> P
         .metadata(*metadata_info.key)
         .master_edition(*edition_info.key)
         .payer(*token_owner_info.key)
+        .spl_token_program(*spl_token_program_info.key)
         .build(delegate_args);
 
     let instruction = match build_result {
@@ -367,6 +369,7 @@ pub fn unlock(_program_id: &Pubkey, accounts: &[AccountInfo], args: UnlockArgs) 
         .metadata(*metadata_info.key)
         .edition(*edition_info.key)
         .payer(*token_owner_info.key)
+        .spl_token_program(*spl_token_program_info.key)
         .build(unlock_args);
 
     let instruction = match build_result {
@@ -435,6 +438,7 @@ pub fn programmable_lock(
         .token_record(*token_record_info.key)
         .authorization_rules(*rule_set_info.key)
         .payer(*token_owner_info.key)
+        .spl_token_program(*spl_token_program_info.key)
         .build(delegate_args);
 
     let instruction = match build_result {
@@ -476,6 +480,7 @@ pub fn programmable_lock(
         .edition(*edition_info.key)
         .token_record(*token_record_info.key)
         .payer(*token_owner_info.key)
+        .spl_token_program(*spl_token_program_info.key)
         .build(lock_args);
 
     let instruction = match build_result {
@@ -543,6 +548,7 @@ pub fn programmable_unlock(
         .token_record(*token_record_info.key)
         .authorization_rules(*rule_set_info.key)
         .payer(*token_owner_info.key)
+        .spl_token_program(*spl_token_program_info.key)
         .build(unlock_args);
 
     let instruction = match build_result {
@@ -575,6 +581,8 @@ pub fn delegate_transfer(
     accounts: &[AccountInfo],
     args: DelegateTransferArgs,
 ) -> ProgramResult {
+    msg!("Rooster: DelegateTransfer");
+
     let account_iter = &mut accounts.iter();
     let authority_info = next_account_info(account_iter)?;
     let rooster_pda_info = next_account_info(account_iter)?;
@@ -618,6 +626,7 @@ pub fn delegate_transfer(
         .destination_token_record(*destination_token_record_info.key)
         .authorization_rules(*rule_set_info.key)
         .authorization_rules_program(*mpl_token_auth_rules_program_info.key)
+        .spl_token_program(*spl_token_program_info.key)
         .payer(*authority_info.key);
 
     msg!("building transfer instruction");


### PR DESCRIPTION
This PR updates the instruction builders and processors to allow the use of multiple spl-token program versions.